### PR TITLE
Fixing close trace files

### DIFF
--- a/libcorsaro/corsaro_file.c
+++ b/libcorsaro/corsaro_file.c
@@ -450,7 +450,8 @@ void corsaro_file_rclose(corsaro_file_in_t *file)
 	}
       /* just for sanity */
       file->wand_io = NULL;
-
+      break;
+            
     default:
       /* do nothing - it was already freed? */
       /* leave the assert here for when people are debugging */


### PR DESCRIPTION
Added missing 'break' in the 'case CORSARO_FILE_MODE_TRACE:' of 'corsaro_file_rclose()'. It caused falling in the assert(0) when using pcap files and pcap interfaces
