### PR TITLE
Fix a couple of problems

### DIFF
--- a/libcorsaro/corsaro.h
+++ b/libcorsaro/corsaro.h
@@ -26,8 +26,6 @@
 #ifndef __CORSARO_H
 #define __CORSARO_H
 
-#include "config.h"
-
 #include "libtrace.h"
 #include "wandio.h"
 

--- a/libcorsaro/corsaro_io.h
+++ b/libcorsaro/corsaro_io.h
@@ -26,8 +26,6 @@
 #ifndef __CORSARO_IO_H
 #define __CORSARO_IO_H
 
-#include "config.h"
-
 #include "corsaro_int.h"
 
 #include "corsaro_file.h"

--- a/libcorsaro/corsaro_log.h
+++ b/libcorsaro/corsaro_log.h
@@ -26,8 +26,6 @@
 #ifndef __CORSARO_LOG_H
 #define __CORSARO_LOG_H
 
-#include "config.h"
-
 #include <stdarg.h>
 
 #include "corsaro_int.h"

--- a/tools/cors-ft-aggregate.c
+++ b/tools/cors-ft-aggregate.c
@@ -30,6 +30,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "config.h"
+
 #include "libtrace.h"
 
 #include "corsaro.h"

--- a/tools/cors-trace2tuple.c
+++ b/tools/cors-trace2tuple.c
@@ -58,7 +58,6 @@
 #include <signal.h>
 
 #include "libtrace.h"
-#include "lt_inttypes.h"
 
 struct libtrace_t *trace;
 


### PR DESCRIPTION
First one was as discussed in an email that lt_inttypes.h no longer exists in recent versions of libtrace.

The other one is config.h should not really be exposed to the public headers as it will generate an error if used. The patch set here only gets you as far as it will compile the library without this include in the three offending public header files and if other files then depend on config.h, they will need to be changed accordingly.